### PR TITLE
Allow Optional Registry Credentials

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -18,8 +18,11 @@ spec:
       annotations:
         redeployOnChange: "{{ .Values.container.redeployOnChange }}"
     spec:
-    
       restartPolicy: {{ .Values.container.restartPolicy }}
+      {{- if .Values.imagePullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.imagePullSecret }}
+      {{- end }}
       containers:
         - name: {{ .Values.name }}
           image: {{ .Values.image }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -9,7 +9,6 @@ postgresHost: mine-support-user-postgres
 postgresServiceName: mine-support-user-postgres
 postgresExternalName: host.docker.internal
 postgresPort: 5432
-imagePullSecret:
 service:
   type: ClusterIP
   port: 80

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,6 +1,7 @@
 environment: development
 name: mine-support-user-service
 image: mine-support-user-service
+imagePullSecret:
 postgresUsername: postgres@mine-support2
 postgresPassword: changeme
 postgresDatabase: mine_users
@@ -8,6 +9,7 @@ postgresHost: mine-support-user-postgres
 postgresServiceName: mine-support-user-postgres
 postgresExternalName: host.docker.internal
 postgresPort: 5432
+imagePullSecret:
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FPD-440

To deploy from a private registry into a Kubernetes cluster registry
credentials must be supplied. this PR adds configuration to the
deployment chart to allow authentication.