### PR TITLE
Document postgresHost and postgresExternalName

### DIFF
--- a/helm/ffc-demo-user-service/development-values.yaml
+++ b/helm/ffc-demo-user-service/development-values.yaml
@@ -1,2 +1,1 @@
 postgresHost: ffc-demo-user-postgres-postgresql
-postgresExternalName:

--- a/helm/ffc-demo-user-service/values.yaml
+++ b/helm/ffc-demo-user-service/values.yaml
@@ -10,7 +10,7 @@ postgresHost: ffc-demo-user-postgres
 # postgresExternalName is the external host name to which PostgreSQL
 # requests should be forwarded. If empty, PostgreSQL is assumed to be
 # within the cluster and accessible via postgresHost
-postgresExternalName: host.docker.internal
+postgresExternalName:
 postgresPort: 5432
 service:
   type: ClusterIP

--- a/helm/ffc-demo-user-service/values.yaml
+++ b/helm/ffc-demo-user-service/values.yaml
@@ -5,7 +5,11 @@ imagePullSecret:
 postgresUsername: postgres@mine-support2
 postgresPassword: changeme
 postgresDatabase: mine_users
+# postgresHost is the host name of the PostgreSQL service
 postgresHost: ffc-demo-user-postgres
+# postgresExternalName is the external host name to which PostgreSQL
+# requests should be forwarded. If empty, PostgreSQL is assumed to be
+# within the cluster and accessible via postgresHost
 postgresExternalName: host.docker.internal
 postgresPort: 5432
 service:


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PSD-227

These two variables have caused confusion. Values should be documented
in values.yaml, as per official Helm best practices.