### PR TITLE
Remove test ouput in final cleanup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('defra-library@separate-test-cleanup')
+@Library('defra-library@0.0.7')
 import uk.gov.defra.ffc.DefraUtils
 def defraUtils = new DefraUtils()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ node {
       defraUtils.runTests(imageName, BUILD_NUMBER)
     }
     stage('SonarQube analysis') {
-      sh "sed -i -e 's/\/usr\/src\/app/./g' ./test-output/lcov.info"
+      sh "sed -i -e 's/\\/usr\\/src\\/app/./g' ./test-output/lcov.info"
       defraUtils.analyseCode(sonarQubeEnv, sonarScanner, ['sonar.projectKey' : repoName, 'sonar.sources' : '.'])
     }
     stage("Code quality gate") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ node {
       defraUtils.runTests(imageName, BUILD_NUMBER)
     }
     stage('SonarQube analysis') {
-      replaceInFile('\/usr\/src\/app', '.', './test-output/lcov.info')
+      replaceInFile('\\/usr\\/src\\/app', '.', './test-output/lcov.info')
       defraUtils.analyseCode(sonarQubeEnv, sonarScanner, ['sonar.projectKey' : repoName, 'sonar.sources' : '.'])
     }
     stage("Code quality gate") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,10 @@ def sonarQubeEnv = 'SonarQube'
 def sonarScanner = 'SonarScanner'
 def timeoutInMinutes = 5
 
+def replaceInFile(from, to, file) {
+  sh "sed -i -e 's/$from/$to/g' $file"  
+}
+
 node {
   checkout scm
   try {
@@ -31,7 +35,7 @@ node {
       defraUtils.runTests(imageName, BUILD_NUMBER)
     }
     stage('SonarQube analysis') {
-      sh "sed -i -e 's/\\/usr\\/src\\/app/./g' ./test-output/lcov.info"
+      replaceInFile('/usr/src/app', '.', './test-output/lcov.info')
       defraUtils.analyseCode(sonarQubeEnv, sonarScanner, ['sonar.projectKey' : repoName, 'sonar.sources' : '.'])
     }
     stage("Code quality gate") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,10 +17,6 @@ def localSrcFolder = '.'
 def lcovFile = './test-output/lcov.info'
 def timeoutInMinutes = 5
 
-def replaceInFile(from, to, file) {
-  sh "sed -i -e 's/$from/$to/g' $file"  
-}
-
 node {
   checkout scm
   try {
@@ -38,7 +34,7 @@ node {
       defraUtils.runTests(imageName, BUILD_NUMBER)
     }
     stage('Fix absolute paths in lcov file') {
-      replaceInFile(containerSrcFolder, localSrcFolder, lcovFile)
+      defraUtils.replaceInFile(containerSrcFolder, localSrcFolder, lcovFile)
     }
     stage('SonarQube analysis') {
       defraUtils.analyseCode(sonarQubeEnv, sonarScanner, ['sonar.projectKey' : repoName, 'sonar.sources' : '.'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,6 +73,6 @@ node {
     defraUtils.setGithubStatusFailure(e.message)
     throw e
   } finally {
-      defraUtils.deleteTestOutput(imageName)    
+    defraUtils.deleteTestOutput(imageName)
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,8 +37,10 @@ node {
     stage('Run tests') {
       defraUtils.runTests(imageName, BUILD_NUMBER)
     }
-    stage('SonarQube analysis') {
+    stage('Fix absolute paths in lcov file') {
       replaceInFile(containerSrcFolder, localSrcFolder, lcovFile)
+    }
+    stage('SonarQube analysis') {
       defraUtils.analyseCode(sonarQubeEnv, sonarScanner, ['sonar.projectKey' : repoName, 'sonar.sources' : '.'])
     }
     stage("Code quality gate") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,9 @@ def mergedPrNo = ''
 def containerTag = ''
 def sonarQubeEnv = 'SonarQube'
 def sonarScanner = 'SonarScanner'
+def containerSrcFolder = '\\/usr\\/src\\/app'
+def localSrcFolder = '.'
+def lcovFile = './test-output/lcov.info'
 def timeoutInMinutes = 5
 
 def replaceInFile(from, to, file) {
@@ -35,7 +38,7 @@ node {
       defraUtils.runTests(imageName, BUILD_NUMBER)
     }
     stage('SonarQube analysis') {
-      replaceInFile('\\/usr\\/src\\/app', '.', './test-output/lcov.info')
+      replaceInFile(containerSrcFolder, localSrcFolder, lcovFile)
       defraUtils.analyseCode(sonarQubeEnv, sonarScanner, ['sonar.projectKey' : repoName, 'sonar.sources' : '.'])
     }
     stage("Code quality gate") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('defra-library@0.0.6')
+@Library('defra-library@separate-test-cleanup')
 import uk.gov.defra.ffc.DefraUtils
 def defraUtils = new DefraUtils()
 
@@ -29,6 +29,7 @@ node {
     }
     stage('Run tests') {
       defraUtils.runTests(imageName, BUILD_NUMBER)
+      defraUtils.deleteTestOutput(imageName)
     }
     stage('SonarQube analysis') {
       defraUtils.analyseCode(sonarQubeEnv, sonarScanner, ['sonar.projectKey' : repoName, 'sonar.sources' : '.'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,7 @@ node {
       defraUtils.runTests(imageName, BUILD_NUMBER)
     }
     stage('SonarQube analysis') {
+      sh "sed -i -e 's/\/usr\/src\/app/./g' ./test-output/lcov.info"
       defraUtils.analyseCode(sonarQubeEnv, sonarScanner, ['sonar.projectKey' : repoName, 'sonar.sources' : '.'])
     }
     stage("Code quality gate") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,6 @@ node {
     }
     stage('Run tests') {
       defraUtils.runTests(imageName, BUILD_NUMBER)
-      defraUtils.deleteTestOutput(imageName)
     }
     stage('SonarQube analysis') {
       defraUtils.analyseCode(sonarQubeEnv, sonarScanner, ['sonar.projectKey' : repoName, 'sonar.sources' : '.'])
@@ -73,5 +72,7 @@ node {
   } catch(e) {
     defraUtils.setGithubStatusFailure(e.message)
     throw e
+  } finally {
+      defraUtils.deleteTestOutput(imageName)    
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ node {
       defraUtils.runTests(imageName, BUILD_NUMBER)
     }
     stage('SonarQube analysis') {
-      replaceInFile('/usr/src/app', '.', './test-output/lcov.info')
+      replaceInFile('\/usr\/src\/app', '.', './test-output/lcov.info')
       defraUtils.analyseCode(sonarQubeEnv, sonarScanner, ['sonar.projectKey' : repoName, 'sonar.sources' : '.'])
     }
     stage("Code quality gate") {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PSD-420

The existing jenkins library deletes test output files after running the
tests.

These files are required by SonarQube, this PR moves to a new release of
the Jenkins library which does not delete the files, and deletes the
files in a final cleanup step