### PR TITLE
Halt Jenkins build on pipeline failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('defra-library@0.0.7')
+@Library('defra-library@halt-on-test-failure')
 import uk.gov.defra.ffc.DefraUtils
 def defraUtils = new DefraUtils()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('defra-library@halt-on-test-failure')
+@Library('defra-library@0.0.8')
 import uk.gov.defra.ffc.DefraUtils
 def defraUtils = new DefraUtils()
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -46,7 +46,7 @@ describe('Web test', () => {
     }
 
     const response = await server.inject(options)
-    expect(response.statusCode).toBe(500)
+    expect(response.statusCode).toBe(200)
   })
 
   afterEach(async () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -46,7 +46,7 @@ describe('Web test', () => {
     }
 
     const response = await server.inject(options)
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(500)
   })
 
   afterEach(async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PSD-441

The build currently continues after a test failure.
This PR demonstrates the build not failing on a broken test, then
resolves it with a new version of the shared library